### PR TITLE
Replace Usage of Pip Internal API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,9 @@
 from setuptools import setup, find_packages
 from codecs import open
 from os import path
-try: # for pip >= 10
-    from pip._internal.req import parse_requirements
-    from pip._internal import download
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
-    from pip import download
 
-
-install_reqs = parse_requirements("requirements.txt", session=download.PipSession())
-install_requires = [str(ir.req) for ir in install_reqs]
+with open('requirements.txt','r') as f:
+  install_requires = f.read().splitlines()
 
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
This PR replaces the usage of Pip's internal API in `setup.py`.